### PR TITLE
Added info about using cloud as a file distribution point's failover

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -15511,6 +15511,9 @@ definitions:
       is_master:
         type: boolean
         description: Only one share can be set as master
+      failover_point:
+        type: string
+        description: Name of a file distribution point or "Cloud Distribution Point" to use as failover.
       enable_load_balancing:
         type: boolean
         default: false


### PR DESCRIPTION
It should be in version 10.27
DVM-514